### PR TITLE
Add Ishmerai Vignette

### DIFF
--- a/vignettes/ishmerai/annotations.r
+++ b/vignettes/ishmerai/annotations.r
@@ -30,8 +30,9 @@ setup_cache <- function(data, spek){
 
   # Calculate peer average by measure
   cache$measure_id      <- measure_id
-  cache$comparator_id   <- comparator_id
-  cache$comparator      <- calc_comparator_value(data, spek, measure_id, comparator_id)
+  # Use get0 to handle comparator present.
+  cache$comparator_id   <- get0('comparator_id', ifnotfound=NULL)
+  cache$comparator      <- calc_comparator_value(data, spek, measure_id, cache$comparator_id)
 
   return(cache)
 }
@@ -183,7 +184,11 @@ annotate_loss_content <- function(data, spek){
 
 annotate_comparators <- function(data, spek){
   # comparator_id provided by running environment. Resides in cache.
-  cache$comparator_id
+  if(is.null(cache$comparator_id)){
+    return(NULL)
+    #return(data.frame('id'=character()))
+  }
+
   comp_type <- spekex::type_of_comparator( spekex::lookup_comparator(cache$comparator_id, spek))
 
   is_std <- identical(spekex::SE$STANDARD_COMPARATOR_IRI, comp_type)

--- a/vignettes/ishmerai/annotations.r
+++ b/vignettes/ishmerai/annotations.r
@@ -1,0 +1,199 @@
+library(dplyr, warn.conflicts = FALSE)
+library(tidyr, warn.conflicts = FALSE)
+library(utils, warn.conflicts = FALSE)
+library(rlang, warn.conflicts = FALSE)
+library(stats, warn.conflicts = FALSE)
+library(lubridate, warn.conflicts = FALSE)
+
+############
+# Run Once #
+############
+
+# Setup cache is run once per measure-comparator
+#  The top level env will include comparator_id and measure_id
+setup_cache <- function(data, spek){
+  cache <- list()
+
+  # Id column will always be id
+  cache$id_colname      <- 'id'
+  cache$id_col_sym      <- rlang::sym(cache$id_colname)
+
+  # Hardcode column names.  Extract from spek in subsequent versions.
+  cache$rate_colname    <- 'rate'
+  cache$time_colname    <- 'time'
+  cache$measure_colname <- 'measure'
+
+  # Make a symbol of the  columns
+  cache$rate_col_sym    <- rlang::sym(cache$rate_colname)
+  cache$time_col_sym    <- rlang::sym(cache$time_colname)
+  cache$measure_col_sym <- rlang::sym(cache$measure_colname)
+
+  # Calculate peer average by measure
+  cache$measure_id      <- measure_id
+  cache$comparator_id   <- comparator_id
+  cache$comparator      <- calc_comparator_value(data, spek, measure_id, comparator_id)
+
+  return(cache)
+}
+
+calc_comparator_value <- function(data, spek, m_id, c_id){
+  if(is.null(c_id)){
+    return(NA)
+  }else{
+    comparator <- spekex::lookup_comparator(c_id, spek)
+  }
+
+  val <- spekex::comparison_value_of_comparator(comparator)
+
+  # Assume comparators without values are social comparator.
+  if(is.null(val)){
+    measure <- spekex::lookup_measure(m_id, spek)
+    val <- data %>%
+      summarize(value=mean(rate)) %>%
+      pull(value)
+  }
+
+  return(val)
+}
+
+####################
+# Helper Functions #
+####################
+
+eval_positive_trend <- function(x){
+  len <- length(x)
+  if(len < 2){ return(FALSE) }
+  is_tail_ascending <- !is.unsorted(x, strictly=T)
+  return(is_tail_ascending)
+}
+
+eval_negative_trend <- function(x){
+  len <- length(x)
+  if(len < 2){ return(FALSE) }
+  is_tail_descending <- !is.unsorted(rev(x), strictly=T)
+  return(is_tail_descending)
+}
+
+eval_achievement <- function(x, comp){
+  if(length(x) < 2){ return(FALSE)}
+  bools <- x >= comp
+  return( nth(bools, -2) == FALSE & dplyr::nth(bools, -1) == TRUE )
+}
+
+eval_loss_content <- function(x, comp){
+  if(length(x) < 2){ return(FALSE)}
+  bools <- x >= comp
+  return( nth(bools, -2) == TRUE & dplyr::nth(bools, -1) == FALSE )
+}
+
+
+########################
+# Annotation Functions #
+########################
+
+annotate_negative_gap <- function(data, spek){
+  rate <- cache$rate_col_sym
+  time <- cache$time_col_sym
+  id <- cache$id_col_sym
+
+  data %>%
+    dplyr::filter(!!time == max(!!time)) %>%
+    group_by(!!id) %>%
+    summarize(negative_gap = rate < cache$comparator)
+}
+
+annotate_positive_gap <- function(data, spek){
+  rate <- cache$rate_col_sym
+  time <- cache$time_col_sym
+  id <- cache$id_col_sym
+
+  data %>%
+    dplyr::filter(!!time == max(!!time)) %>%
+    group_by(!!id) %>%
+    summarize(positive_gap = (!!rate > cache$comparator))
+}
+
+annotate_negative_trend <- function(data, spek){
+  rate <- cache$rate_col_sym
+  time <- cache$time_col_sym
+  id <- cache$id_col_sym
+
+  max_month <- as_date(max(data[[time]]))
+  min_month <- max_month %m-% months(1)
+
+  data %>%
+    dplyr::filter(!!time >= min_month) %>%
+    group_by(!!id) %>%
+    summarize(negative_trend = eval_negative_trend(!!rate))
+}
+
+annotate_positive_trend <- function(data, spek){
+  rate <- cache$rate_col_sym
+  time <- cache$time_col_sym
+  id <- cache$id_col_sym
+
+  max_month <- as_date(max(data[[time]]))
+  min_month <- max_month %m-% months(1)
+
+  data %>%
+    dplyr::filter(!!time >= min_month) %>%
+    group_by(!!id) %>%
+    summarize(positive_trend = eval_positive_trend(!!rate))
+}
+
+annotate_achievement <- function(data, spek){
+  time <- cache$time_col_sym
+  rate <- cache$rate_col_sym
+  id <- cache$id_col_sym
+
+  all_ids_df <- data %>% select(!!id) %>% distinct
+
+  elidgibile_ids <- data %>%
+    dplyr::filter(!!time == max(!!time)) %>%
+    pull(!!id) %>%
+    unique
+
+  data %>%
+    dplyr::filter(!!id %in% elidgibile_ids) %>%
+    arrange(!!time) %>%
+    group_by(!!id) %>%
+    summarize( achievement = eval_achievement(!!rate,cache$comparator)) %>%
+    right_join(all_ids_df)
+}
+
+annotate_loss_content <- function(data, spek){
+  time <- cache$time_col_sym
+  rate <- cache$rate_col_sym
+  id <- cache$id_col_sym
+
+  all_ids_df <- data %>% select(!!id) %>% distinct
+
+  elidgibile_ids <- data %>%
+    dplyr::filter(!!time == max(!!time)) %>%
+    pull(!!id) %>%
+    unique
+
+  data %>%
+    dplyr::filter(!!id %in% elidgibile_ids) %>%
+    arrange(!!time) %>%
+    group_by(!!id) %>%
+    summarize( loss_content = eval_loss_content(!!rate,cache$comparator)) %>%
+    right_join(all_ids_df)
+}
+
+annotate_comparators <- function(data, spek){
+  # comparator_id provided by running environment. Resides in cache.
+  cache$comparator_id
+  comp_type <- spekex::type_of_comparator( spekex::lookup_comparator(cache$comparator_id, spek))
+
+  is_std <- identical(spekex::SE$STANDARD_COMPARATOR_IRI, comp_type)
+  is_soc <- identical(spekex::SE$SOCIAL_COMPARATOR_IRI, comp_type)
+  is_gol <- identical(spekex::SE$GOAL_COMPARATOR_IRI, comp_type)
+
+  id <- cache$id_col_sym
+
+  # Do three annotations at once.
+  data %>% group_by(!!id) %>% summarize(standard_comparator = is_std,
+                                        social_comparator = is_soc,
+                                        goal_comparator = is_gol)
+}

--- a/vignettes/ishmerai/causal_pathways.json
+++ b/vignettes/ishmerai/causal_pathways.json
@@ -1,0 +1,80 @@
+{
+  "@context": {
+    "@vocab":                                           "http://schema.org/",
+    "obo":                                              "http://purl.obolibrary.org/obo/",
+    "cpo-Mechanism":                                    "http://purl.obolibrary.org/obo/cpo_0000001",
+    "cpo-Precondition":                                 "http://purl.obolibrary.org/obo/cpo_0000002",
+    "cpo-Moderator":                                    "http://purl.obolibrary.org/obo/cpo_0000005",
+    "cpo-ProximalOutcome":                              "http://purl.obolibrary.org/obo/cpo_0000006",
+    "cpo-DistalOutcome":                                "http://purl.obolibrary.org/obo/cpo_0000007",
+    "cpo-CognitiveModerator":                           "http://purl.obolibrary.org/obo/cpo_0000008",
+    "cpo-OrganizationalModerator":                      "http://purl.obolibrary.org/obo/cpo_0000009",
+    "cpo-CausalPathway":                                "http://purl.obolibrary.org/obo/cpo_0000029",
+    "cpo-ImplementationStrategy":                       "http://purl.obolibrary.org/obo/cpo_0000053",
+    "cpo-MechanismPrecondition":                        "http://purl.obolibrary.org/obo/cpo_0000054",
+    "cpo-OutcomePrecondition":                          "http://purl.obolibrary.org/obo/cpo_0000055",
+    "psdo-RecipientElement":                            "http://purl.obolibrary.org/obo/psdo_0000041",
+    "psdo-GoalComparatorElement":                       "http://purl.obolibrary.org/obo/psdo_0000046",
+    "psdo-GoalComparatorContent":                       "http://purl.obolibrary.org/obo/psdo_0000094",
+    "psdo-RecipientContent":                            "http://purl.obolibrary.org/obo/psdo_0000097",
+    "psdo-PositivePerformanceTrendContent":             "http://purl.obolibrary.org/obo/psdo_0000099",
+    "psdo-NegativePerformanceTrendContent":             "http://purl.obolibrary.org/obo/psdo_0000100",
+    "psdo-PositivePerformanceGapContent":               "http://purl.obolibrary.org/obo/psdo_0000104",
+    "psdo-NegativePerformanceGapContent":               "http://purl.obolibrary.org/obo/psdo_0000105",
+    "psdo-AchievementContent":                          "http://purl.obolibrary.org/obo/psdo_0000112",
+    "psdo-LossContent":                                 "http://purl.obolibrary.org/obo/psdo_0000113",
+    "psdo-NegativePerformanceGapSet":                   "http://purl.obolibrary.org/obo/psdo_0000116",
+    "psdo-PositivePerformanceGapSet":                   "http://purl.obolibrary.org/obo/psdo_0000117",
+    "psdo-NegativePerformanceTrendSet":                 "http://purl.obolibrary.org/obo/psdo_0000119",
+    "psdo-PositivePerformanceTrendSet":                 "http://purl.obolibrary.org/obo/psdo_0000120",
+    "psdo-AchievementSet":                              "http://purl.obolibrary.org/obo/psdo_0000121",
+    "psdo-LossSet":                                     "http://purl.obolibrary.org/obo/psdo_0000122",
+    "slowmo":                                           "http://example.com/slowmo#",
+    "slowmo-PerformanceGapSize":                        "http://example.com/slowmo#PerformanceGapSize",
+    "slowmo-TrendSlope":                                "http://example.com/slowmo#TrendSlope",
+    "slowmo-PerformanceGapSize":                        "http://example.com/slowmo#PerformanceGapSize",
+    "slowmo-HasPrecondition":                           "http://example.com/slowmo#HasPrecondition",
+    "slowmo-HasModerator":                              "http://example.com/slowmo#HasModerator",
+    "slowmo-InterventionContent":                       "http://example.com/slowmo#InterventionContent",
+    "slowmo-Habituation":                               "http://example.com/slowmo#Habituation",
+    "slowmo-TimeSinceLastAchievement":                  "http://example.com/slowmo#TimeSinceLastAchievement",
+    "slowmo-RegulatoryFit":                             "http://example.com/slowmo#RegulatoryFit"
+  },
+
+  "@graph": [
+    {
+      "@id": "http://feedbacktailor.org/ftkb#Worsening",
+      "@type": "http://purl.obolibrary.org/obo/cpo_0000029",
+      "name": "worsening",
+
+      "cpo-ImplementationStrategy": "Show a performance that became worse",
+
+      "slowmo-InterventionContent": ["BCT 2.2 Feedback on behavior", "BCT 2.7 Feedback on outcomes of behavior"],
+
+      "cpo-Mechanism": ["knowledge"],
+
+      "slowmo-HasPrecondition":[
+        {"@type": "http://purl.obolibrary.org/obo/psdo_0000041"},
+        {"@type": "http://purl.obolibrary.org/obo/psdo_0000100"},
+        {"@type": "http://purl.obolibrary.org/obo/psdo_0000119"}
+      ],
+
+      "slowmo-HasModerator":[
+        {"@type": "http://example.com/slowmo#RegulatoryFit"},
+        {"@type": "http://example.com/slowmo#Habituation"},
+        {"@type": "http://example.com/slowmo#TrendSlope"}
+      ],
+
+      "cpo-ProximalOutcome": ["clinical process performance improvement"],
+
+      "cpo-DistalOutcome": "clinical outcome performance improvement",
+
+      "slowmo-ExampleKeyMessage": "Your performance is getting worse"
+    }
+  ]
+}
+
+
+
+
+

--- a/vignettes/ishmerai/performance.csv
+++ b/vignettes/ishmerai/performance.csv
@@ -1,0 +1,4 @@
+measure,performer,time,rate
+demo,Ishmerai,2020-07-01,0.96
+demo,Ishmerai,2020-08-01,0.95
+demo,Ishmerai,2020-09-01,0.93

--- a/vignettes/ishmerai/spek.json
+++ b/vignettes/ishmerai/spek.json
@@ -1,0 +1,97 @@
+{
+  "@context": {
+    "@vocab": "http://schema.org/",
+    "slowmo": "http://example.com/slowmo#",
+    "csvw":   "http://www.w3.org/ns/csvw#", 
+    "dc":     "http://purl.org/dc/terms/",
+    "psdo":   "http://purl.obolibrary.org/obo/",
+    "IAO":    "http://purl.obolibrary.org/obo/",
+    "slowmo-Measure":                  "http://example.com/slowmo#Measure",
+    "slowmo-IsAboutPerformer":         "http://example.com/slowmo#IsAboutPerformer",
+    "slowmo-ColumnUse":                "http://example.com/slowmo#ColumnUse",
+    "slowmo-IsAboutTemplate":          "http://example.com/slowmo#IsAboutTemplate",
+    "slowmo-spek":                     "http://example.com/slowmo#spek",
+    "slowmo-IsAboutCausalPathway":     "http://example.com/slowmo#IsAboutCausalPathway",
+    "slowmo-IsAboutOrganization":      "http://example.com/slowmo#IsAboutOrganization",
+    "slowmo-IsAboutMeasure":           "http://example.com/slowmo#IsAboutMeasure",
+    "slowmo-InputTable":               "http://example.com/slowmo#InputTable",
+    "slowmo-WithComparator":           "http://example.com/slowmo#WithComparator",
+    "has_part":        "http://purl.obolibrary.org/obo/bfo#BFO_0000051",
+    "has_disposition": "http://purl.obolibrary.org/obo/RO_0000091",
+    "IAO-IsAbout":		 "http://purl.obolibrary.org/obo/IAO_0000136"
+  },
+  "@id": "http://example.com/app#mpog-aspire",
+  "@type": "http://example.com/slowmo#spek",
+  "slowmo:IsAboutOrganization": {
+    "@type": "Organization",
+    "address": {
+      "@type": "PostalAddress",
+      "addressCountry": "USA",
+      "addressRegion": "MI",
+      "streetAddress": "DLHS, 1161 NIB, 300 N Ingalls St.",
+      "postalCode": "48109",
+      "name": "DisplayLab"
+    }
+  },
+  "slowmo:IsAboutMeasure":[
+    { "@id": "_:m1",
+      "@type": "http://purl.obolibrary.org/obo/psdo_0000102",
+      "dc:title": "Demonstration Measure",
+      "identifier": "demo"
+    }
+  ],
+  "slowmo:IsAboutTemplate": [{ "@id": "http://feedbacktailor.org/ftkb#PerformanceWorsening" }],
+  "slowmo:InputTable":{
+    "@type": "http://www.w3.org/ns/csvw#Table",
+    "dc:title": "Demonstration Performance Data", 
+    "csvw:dialect": {
+      "csvw:commentPrefix": "", 
+      "csvw:delimiter": ",", 
+      "csvw:doubleQuote": true, 
+      "csvw:encoding": "utf-8", 
+      "csvw:header": true, 
+      "csvw:headerRowCount": "1", 
+      "csvw:lineTerminators": [
+        "\\n"
+      ], 
+      "csvw:quoteChar": "\"", 
+      "csvw:skipBlankRows": true, 
+      "csvw:skipColumns": "", 
+      "csvw:skipInitialSpace": false, 
+      "csvw:skipRows": "", 
+      "csvw:trim": false
+    }, 
+    "csvw:tableSchema": {
+      "csvw:columns": [
+        {
+          "csvw:datatype": "string", 
+          "dc:description": "Name of measurement", 
+          "csvw:name": "measure", 
+          "csvw:title": "Measure",
+          "slowmo:ColumnUse": "measure"
+        },
+        {
+          "csvw:datatype": "string", 
+          "dc:description": "Name of performer", 
+          "csvw:name": "performer", 
+          "csvw:title": "Performer",
+          "slowmo:ColumnUse": "identifier"
+        },
+        {
+          "csvw:datatype": "date", 
+          "dc:description": "Performance calendar month.", 
+          "csvw:name": "time", 
+          "csvw:title": "Time",
+          "slowmo:ColumnUse": "time"
+        },
+        {
+          "csvw:datatype": "double", 
+          "dc:description": "Example measured rate", 
+          "csvw:name": "rate", 
+          "csvw:title": "Measured Rate",
+          "slowmo:ColumnUse": "rate"
+        }
+      ]
+    }
+  }
+}

--- a/vignettes/ishmerai/spek.json
+++ b/vignettes/ishmerai/spek.json
@@ -40,7 +40,7 @@
       "identifier": "demo"
     }
   ],
-  "slowmo:IsAboutTemplate": [{ "@id": "http://feedbacktailor.org/ftkb#PerformanceWorsening" }],
+  "slowmo:IsAboutTemplate": [{ "@id": "http://feedbacktailor.org/ftkb#PerformanceWorseningBar" }],
   "slowmo:InputTable":{
     "@type": "http://www.w3.org/ns/csvw#Table",
     "dc:title": "Demonstration Performance Data", 

--- a/vignettes/ishmerai/synopsis.md
+++ b/vignettes/ishmerai/synopsis.md
@@ -1,0 +1,26 @@
+# Worsening Example
+
+## Performance data
+Ishmerai has performance levels of 96% for July 2020, 95% for August 2020, and 93% for September 2020.
+
+## Peformer annotations
+This data set should result in an annotation that there is information content about a negative performance trend for Ishmerai:
+1. Negative performance trend content (http://purl.obolibrary.org/obo/psdo_0000100)
+
+## Template annotations
+The performance_worsening template is about a negative performance trend set:
+1. Negative performance trend set (http://purl.obolibrary.org/obo/psdo_0000119)
+
+## Resulting Candidates
+The candidate produced for Ishmerai has:
+1. Negative performance trend content (http://purl.obolibrary.org/obo/psdo_0000100)
+2. Negative performance trend set (http://purl.obolibrary.org/obo/psdo_0000119)
+
+## Causal Pathway Preconditions
+The worsening causal pathway has preconditions:
+1. Negative performance trend content (http://purl.obolibrary.org/obo/psdo_0000100)
+2. Negative performance trend set (http://purl.obolibrary.org/obo/psdo_0000119)
+
+## Evaluation result
+The candidate is found to be acceptable by the causal pathway worsening.
+

--- a/vignettes/ishmerai/templates.json
+++ b/vignettes/ishmerai/templates.json
@@ -1,0 +1,34 @@
+ {
+  "@context": {
+    "@vocab":                               "http://schema.org/",
+    "obo":                                  "http://purl.obolibrary.org/obo/",
+    "slowmo":                               "http://example.com/slowmo#",
+    "psdo-PerformanceSummaryDocument":      "http://purl.obolibrary.org/obo/psdo_0000098",
+    "psdo-NegativePerformanceGapSet":       "http://purl.obolibrary.org/obo/psdo_0000116",
+    "psdo-RecipientElement":                "http://purl.obolibrary.org/obo/psdo_0000041",
+    "psdo-GoalComparatorElement":           "http://purl.obolibrary.org/obo/psdo_0000046",
+    "psdo-PerformanceSummaryDisplay":       "http://purl.obolibrary.org/obo/psdo_0000003",
+    "psdo-PerformanceSummaryTextualEntity": "http://purl.obolibrary.org/obo/psdo_0000110",
+    "psdo-NegativePerformanceTrendSet":     "http://purl.obolibrary.org/obo/psdo_0000119",
+    "psdo-AchievementSet":                  "http://purl.obolibrary.org/obo/psdo_0000121",
+    "psdo-Template":                        "http://purl.obolibrary.org/obo/psdo_0000002",
+    "IAO-IsAbout":                          "http://purl.obolibrary.org/obo/IAO_0000136",
+    "schema-name":                          "http://schema.org/name"
+  },
+
+  "@graph": [
+    {
+      "@id": "http://feedbacktailor.org/ftkb#PerformanceWorseningBar",
+      "@type": "http://purl.obolibrary.org/obo/psdo_0000002",
+      "name": "performance worsening",
+
+      "http://purl.obolibrary.org/obo/IAO_0000136":[
+
+        {"@type": "http://purl.obolibrary.org/obo/psdo_0000041"},
+        {"@type": "http://purl.obolibrary.org/obo/psdo_0000119"}
+      ],
+      "psdo:PerformanceSummaryTextualEntity": "Your performance is getting worse for the measure [measure_details]",
+      "psdo:PerformanceSummaryDisplay": "https://github.com/Display-Lab/card-study/blob/master/cards/fig_comp_bar.R"
+    }
+  ]
+}

--- a/vignettes/scripts/run_vignette.sh
+++ b/vignettes/scripts/run_vignette.sh
@@ -2,19 +2,31 @@
 # This is designed to be run from within a vignette directory
 # Assumes bitstomach.sh, cansmash, fuseki-server, and thinkpudding.sh are on PATH.
 
+COL_WIDTH=30
+LOG_FILE=vignette.log
+
 # Create outputs directory
 mkdir -p outputs
 
+# Create log file
+date > ${LOG_FILE}
+
 # Run bitstomach on performance data, spek, and annotations
-echo "Running BitStomach"
-bitstomach.sh -s spek.json -d performance.csv -a annotations.r 2> vignette.log | jq . > outputs/spek_bs.json
+printf "%-${COL_WIDTH}s" "Running BitStomach..." | tee -a ${LOG_FILE}
+printf "\n" >> ${LOG_FILE}
+bitstomach.sh -s spek.json -d performance.csv -a annotations.r 2>> ${LOG_FILE} | jq . > outputs/spek_bs.json
+printf "exit status: %d\n" "${?}"
 
 # Run candidate smasher on spek (spek_bs.json) and templates
-echo "Running CandidateSmasher"
-cansmash --path=outputs/spek_bs.json --md-source=templates.json 2>> vignette.log | jq . > outputs/spek_cs.json
+printf "%-${COL_WIDTH}s" "Running CandidateSmasher..." | tee -a ${LOG_FILE}
+printf "\n" >> ${LOG_FILE}
+cansmash --path=outputs/spek_bs.json --md-source=templates.json 2>> ${LOG_FILE} | jq . > outputs/spek_cs.json
+printf "exit status: %d\n" "${?}"
 
 # Run think pudding on spek (spek_cs.json) and causal pathways
-echo "Running ThinkPudding"
-thinkpudding.sh -s outputs/spek_cs.json -p causal_pathways.json 2>> vignette.log > outputs/spek_tp.json
+printf "%-${COL_WIDTH}s" "Running ThinkPudding..." | tee -a ${LOG_FILE}
+printf "\n" >> ${LOG_FILE}
+thinkpudding.sh -s outputs/spek_cs.json -p causal_pathways.json 2>> ${LOG_FILE} > outputs/spek_tp.json
+printf "exit status: %d\n" "${?}"
 
-echo "Log written to vignette.log"
+printf "Log written to ${LOG_FILE}\n"


### PR DESCRIPTION
The Ishmerai vignette is a case where there is a single measure with no comparator.

Making the Ishmerai vignette run as expected requires updating to Bitstomach v0.15.1. (Check by running `bitstomach.sh --version`). That will handle the case where an annotation returns NULL instead of a table of `id | disposition`.  This is the case with `annotate_comparator` which normally adds the disposition about if a comparator goal or social.

Quality of life improvements for the `run_vignette.sh` script:
- It emits the exit status of each component to standard out.  Expected exit status is 0.  Anything else indicates there was a problem.
- The output indicating which application is about to run is now also written to the log file.

